### PR TITLE
Fix upload button not opening file chooser

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -17,7 +17,7 @@
         <span class="title">Simple Viewer</span>
         <select name="models" id="models"></select>
         <button id="upload" title="Upload New Model">Upload</button>
-        <input type="file" id="input" style="width:0;height:0;opacity:0;position:absolute;">
+        <input type="file" id="input" style="position:absolute;left:-10000px;">
     </div>
     <div id="preview"></div>
     <div id="overlay"></div>

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -17,7 +17,7 @@
         <span class="title">Simple Viewer</span>
         <select name="models" id="models"></select>
         <button id="upload" title="Upload New Model">Upload</button>
-        <input style="display: none" type="file" id="input">
+        <input type="file" id="input" style="width:0;height:0;opacity:0;position:absolute;">
     </div>
     <div id="preview"></div>
     <div id="overlay"></div>

--- a/wwwroot/main.js
+++ b/wwwroot/main.js
@@ -1,10 +1,11 @@
 import { initViewer, loadModel } from './viewer.js';
 
-initViewer(document.getElementById('preview')).then(viewer => {
+const viewerPromise = initViewer(document.getElementById('preview'));
+viewerPromise.then(viewer => {
     const urn = window.location.hash?.substring(1);
     setupModelSelection(viewer, urn);
-    setupModelUpload(viewer);
 });
+setupModelUpload(viewerPromise);
 
 async function setupModelSelection(viewer, selectedUrn) {
     const dropdown = document.getElementById('models');
@@ -26,7 +27,7 @@ async function setupModelSelection(viewer, selectedUrn) {
     }
 }
 
-async function setupModelUpload(viewer) {
+async function setupModelUpload(viewerPromise) {
     const upload = document.getElementById('upload');
     const input = document.getElementById('input');
     const models = document.getElementById('models');
@@ -48,7 +49,7 @@ async function setupModelUpload(viewer) {
                 throw new Error(await resp.text());
             }
             const model = await resp.json();
-            setupModelSelection(viewer, model.urn);
+            viewerPromise.then(viewer => setupModelSelection(viewer, model.urn));
         } catch (err) {
             alert(`Could not upload model ${file.name}. See the console for more details.`);
             console.error(err);


### PR DESCRIPTION
## Summary
- ensure hidden file input can be programmatically clicked by removing `display:none`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beb69cd9cc8327bcba706a3f32a137